### PR TITLE
Remove using PureScript internals in JavaScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.pulp-cache
+/.spago
 /bower_components
 /node_modules
 /output

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,0 +1,4 @@
+let upstream =
+      https://github.com/purescript/package-sets/releases/download/psc-0.15.7-20230216/packages.dhall
+        sha256:8d4dc43ba920e029cfc39c122201ed821b37ad1c22bc115ab283bd9fab949eba
+in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,0 +1,16 @@
+{ name = "web-cssom-view"
+, dependencies =
+  [ "aff"
+  , "effect"
+  , "maybe"
+  , "nullable"
+  , "prelude"
+  , "unsafe-coerce"
+  , "web-dom"
+  , "web-events"
+  , "web-geometry"
+  , "web-html"
+  ]
+, packages = ./packages.dhall
+, sources = [ "src/**/*.purs" ]
+}

--- a/spago.lock
+++ b/spago.lock
@@ -1,0 +1,1080 @@
+workspace:
+  packages:
+    web-cssom-view:
+      path: ./
+      dependencies:
+        - aff
+        - web-events
+        - web-geometry
+        - web-html
+      test_dependencies: []
+      build_plan:
+        - aff
+        - arrays
+        - bifunctors
+        - const
+        - contravariant
+        - control
+        - datetime
+        - distributive
+        - effect
+        - either
+        - enums
+        - exceptions
+        - exists
+        - foldable-traversable
+        - foreign
+        - functions
+        - functors
+        - gen
+        - identity
+        - integers
+        - invariant
+        - js-date
+        - lazy
+        - lists
+        - maybe
+        - media-types
+        - newtype
+        - nonempty
+        - now
+        - nullable
+        - numbers
+        - ordered-collections
+        - orders
+        - parallel
+        - partial
+        - prelude
+        - profunctor
+        - refs
+        - safe-coerce
+        - st
+        - strings
+        - tailrec
+        - transformers
+        - tuples
+        - type-equality
+        - unfoldable
+        - unsafe-coerce
+        - web-dom
+        - web-events
+        - web-file
+        - web-geometry
+        - web-html
+        - web-storage
+  package_set:
+    address:
+      registry: 47.12.0
+    compiler: ">=0.15.14 <0.16.0"
+    content:
+      abc-parser: 2.0.1
+      ace: 9.1.0
+      aff: 7.1.0
+      aff-bus: 6.0.0
+      aff-coroutines: 9.0.0
+      aff-promise: 4.0.0
+      aff-retry: 2.0.0
+      affjax: 13.0.0
+      affjax-node: 1.0.0
+      affjax-web: 1.0.0
+      ansi: 7.0.0
+      applicative-phases: 1.0.0
+      argonaut: 9.0.0
+      argonaut-aeson-generic: 0.4.1
+      argonaut-codecs: 9.1.0
+      argonaut-core: 7.0.0
+      argonaut-generic: 8.0.0
+      argonaut-traversals: 10.0.0
+      argparse-basic: 2.0.0
+      array-builder: 0.1.2
+      array-search: 0.5.6
+      arraybuffer: 13.2.0
+      arraybuffer-builder: 3.1.0
+      arraybuffer-types: 3.0.2
+      arrays: 7.3.0
+      arrays-extra: 0.4.4
+      arrays-zipper: 2.0.1
+      ask: 1.0.0
+      assert: 6.0.0
+      assert-multiple: 0.3.4
+      avar: 5.0.0
+      b64: 0.0.8
+      barbies: 1.0.1
+      barlow-lens: 0.9.0
+      bifunctors: 6.0.0
+      bigints: 7.0.1
+      bolson: 0.3.9
+      bookhound: 0.1.7
+      bower-json: 3.0.0
+      call-by-name: 4.0.1
+      canvas: 6.0.0
+      canvas-action: 9.0.0
+      cartesian: 1.0.6
+      catenable-lists: 7.0.0
+      chameleon: 1.0.0
+      chameleon-halogen: 1.0.3
+      chameleon-react-basic: 1.1.0
+      chameleon-styled: 2.5.0
+      chameleon-transformers: 1.0.0
+      channel: 1.0.0
+      checked-exceptions: 3.1.1
+      classless: 0.1.1
+      classless-arbitrary: 0.1.1
+      classless-decode-json: 0.1.1
+      classless-encode-json: 0.1.3
+      classnames: 2.0.0
+      codec: 6.1.0
+      codec-argonaut: 10.0.0
+      codec-json: 1.1.0
+      colors: 7.0.1
+      concur-core: 0.5.0
+      concur-react: 0.5.0
+      concurrent-queues: 3.0.0
+      console: 6.1.0
+      const: 6.0.0
+      contravariant: 6.0.0
+      control: 6.0.0
+      convertable-options: 1.0.0
+      coroutines: 7.0.0
+      css: 6.0.0
+      css-frameworks: 1.0.1
+      data-mvc: 0.0.2
+      datetime: 6.1.0
+      datetime-parsing: 0.2.0
+      debug: 6.0.2
+      decimals: 7.1.0
+      default-values: 1.0.1
+      deku: 0.9.23
+      deno: 0.0.5
+      dissect: 1.0.0
+      distributive: 6.0.0
+      dom-filereader: 7.0.0
+      dom-indexed: 12.0.0
+      dotenv: 4.0.3
+      droplet: 0.6.0
+      dts: 1.0.0
+      dual-numbers: 1.0.2
+      dynamic-buffer: 3.0.1
+      echarts-simple: 0.0.1
+      effect: 4.0.0
+      either: 6.1.0
+      elmish: 0.10.0
+      elmish-enzyme: 0.1.1
+      elmish-hooks: 0.10.0
+      elmish-html: 0.8.1
+      elmish-testing-library: 0.3.1
+      email-validate: 7.0.0
+      encoding: 0.0.8
+      enums: 6.0.1
+      env-names: 0.3.4
+      error: 2.0.0
+      eta-conversion: 0.3.2
+      exceptions: 6.0.0
+      exists: 6.0.0
+      exitcodes: 4.0.0
+      expect-inferred: 3.0.0
+      fahrtwind: 2.0.0
+      fallback: 0.1.0
+      fast-vect: 1.2.0
+      fetch: 4.1.0
+      fetch-argonaut: 1.0.1
+      fetch-core: 5.1.0
+      fetch-yoga-json: 1.1.0
+      filterable: 5.0.0
+      fix-functor: 0.1.0
+      fixed-points: 7.0.0
+      fixed-precision: 5.0.0
+      flame: 1.3.0
+      float32: 2.0.0
+      fmt: 0.2.1
+      foldable-traversable: 6.0.0
+      foreign: 7.0.0
+      foreign-object: 4.1.0
+      foreign-readwrite: 3.4.0
+      forgetmenot: 0.1.0
+      fork: 6.0.0
+      form-urlencoded: 7.0.0
+      formatters: 7.0.0
+      framer-motion: 1.0.1
+      free: 7.1.0
+      freeap: 7.0.0
+      freer-free: 0.0.1
+      freet: 7.0.0
+      functions: 6.0.0
+      functor1: 3.0.0
+      functors: 5.0.0
+      fuzzy: 0.4.0
+      gen: 4.0.0
+      generate-values: 1.0.1
+      generic-router: 0.0.1
+      geojson: 0.0.5
+      geometry-plane: 1.0.3
+      grain: 3.0.0
+      grain-router: 3.0.0
+      grain-virtualized: 3.0.0
+      graphs: 8.1.0
+      group: 4.1.1
+      halogen: 7.0.0
+      halogen-bootstrap5: 2.3.1
+      halogen-css: 10.0.0
+      halogen-echarts-simple: 0.0.4
+      halogen-formless: 4.0.3
+      halogen-helix: 1.0.0
+      halogen-hooks: 0.6.3
+      halogen-hooks-extra: 0.9.0
+      halogen-store: 0.5.4
+      halogen-storybook: 2.0.0
+      halogen-subscriptions: 2.0.0
+      halogen-svg-elems: 8.0.0
+      halogen-typewriter: 1.0.4
+      halogen-vdom: 8.0.0
+      halogen-vdom-string-renderer: 0.5.0
+      heckin: 2.0.1
+      heterogeneous: 0.6.0
+      homogeneous: 0.4.0
+      http-methods: 6.0.0
+      httpurple: 4.0.0
+      humdrum: 0.0.1
+      hyrule: 2.3.8
+      identity: 6.0.0
+      identy: 4.0.1
+      indexed-db: 1.0.0
+      indexed-monad: 3.0.0
+      int64: 3.0.0
+      integers: 6.0.0
+      interpolate: 5.0.2
+      invariant: 6.0.0
+      jarilo: 1.0.1
+      jelly: 0.10.0
+      jelly-router: 0.3.0
+      jelly-signal: 0.4.0
+      jest: 1.0.0
+      js-abort-controller: 1.0.0
+      js-bigints: 2.2.1
+      js-date: 8.0.0
+      js-fetch: 0.2.1
+      js-fileio: 3.0.0
+      js-intl: 1.0.4
+      js-iterators: 0.1.1
+      js-maps: 0.1.2
+      js-promise: 1.0.0
+      js-promise-aff: 1.0.0
+      js-timers: 6.1.0
+      js-uri: 3.1.0
+      json: 1.0.0
+      json-codecs: 5.0.0
+      justifill: 0.5.0
+      jwt: 0.0.9
+      labeled-data: 0.2.0
+      lazy: 6.0.0
+      lazy-joe: 1.0.0
+      lcg: 4.0.0
+      leibniz: 5.0.0
+      liminal: 1.0.1
+      linalg: 6.0.0
+      lists: 7.0.0
+      literals: 1.0.2
+      logging: 3.0.0
+      logging-journald: 0.4.0
+      lumi-components: 18.0.0
+      machines: 7.0.0
+      maps-eager: 0.4.1
+      marionette: 1.0.0
+      marionette-react-basic-hooks: 0.1.1
+      marked: 0.1.0
+      matrices: 5.0.1
+      matryoshka: 1.0.0
+      maybe: 6.0.0
+      media-types: 6.0.0
+      meowclient: 1.0.0
+      midi: 4.0.0
+      milkis: 9.0.0
+      minibench: 4.0.1
+      mmorph: 7.0.0
+      monad-control: 5.0.0
+      monad-logger: 1.3.1
+      monad-loops: 0.5.0
+      monad-unlift: 1.0.1
+      monoid-extras: 0.0.1
+      monoidal: 0.16.0
+      morello: 0.4.0
+      mote: 3.0.0
+      motsunabe: 2.0.0
+      mvc: 0.0.1
+      mysql: 6.0.1
+      n3: 0.1.0
+      nano-id: 1.1.0
+      nanoid: 0.1.0
+      naturals: 3.0.0
+      nested-functor: 0.2.1
+      newtype: 5.0.0
+      nextjs: 0.1.1
+      nextui: 0.2.0
+      node-buffer: 9.0.0
+      node-child-process: 11.1.0
+      node-event-emitter: 3.0.0
+      node-execa: 5.0.0
+      node-fs: 9.1.0
+      node-glob-basic: 1.3.0
+      node-http: 9.1.0
+      node-http2: 1.1.1
+      node-human-signals: 1.0.0
+      node-net: 5.1.0
+      node-os: 5.1.0
+      node-path: 5.0.0
+      node-process: 11.2.0
+      node-readline: 8.1.0
+      node-sqlite3: 8.0.0
+      node-streams: 9.0.0
+      node-tls: 0.3.1
+      node-url: 7.0.1
+      node-zlib: 0.4.0
+      nonempty: 7.0.0
+      now: 6.0.0
+      npm-package-json: 2.0.0
+      nullable: 6.0.0
+      numberfield: 0.1.0
+      numbers: 9.0.1
+      oak: 3.1.1
+      oak-debug: 1.2.2
+      object-maps: 0.3.0
+      ocarina: 1.5.4
+      open-folds: 6.3.0
+      open-memoize: 6.1.0
+      open-pairing: 6.1.0
+      options: 7.0.0
+      optparse: 5.0.1
+      ordered-collections: 3.1.1
+      ordered-set: 0.4.0
+      orders: 6.0.0
+      owoify: 1.2.0
+      pairs: 9.0.1
+      parallel: 7.0.0
+      parsing: 10.2.0
+      parsing-dataview: 3.2.4
+      partial: 4.0.0
+      pathy: 9.0.0
+      pha: 0.13.0
+      phaser: 0.7.0
+      phylio: 1.1.2
+      pipes: 8.0.0
+      pirates-charm: 0.0.1
+      pmock: 0.9.0
+      point-free: 1.0.0
+      pointed-list: 0.5.1
+      polymorphic-vectors: 4.0.0
+      posix-types: 6.0.0
+      precise: 6.0.0
+      precise-datetime: 7.0.0
+      prelude: 6.0.1
+      prettier-printer: 3.0.0
+      profunctor: 6.0.0
+      profunctor-lenses: 8.0.0
+      protobuf: 4.3.0
+      psa-utils: 8.0.0
+      psci-support: 6.0.0
+      qualified-do: 2.2.0
+      quantities: 12.2.0
+      quickcheck: 8.0.1
+      quickcheck-combinators: 0.1.3
+      quickcheck-laws: 7.0.0
+      quickcheck-utf8: 0.0.0
+      random: 6.0.0
+      rationals: 6.0.0
+      rdf: 0.1.0
+      react: 11.0.0
+      react-aria: 0.2.0
+      react-basic: 17.0.0
+      react-basic-classic: 3.0.0
+      react-basic-dnd: 10.1.0
+      react-basic-dom: 6.1.0
+      react-basic-emotion: 7.1.0
+      react-basic-hooks: 8.2.0
+      react-basic-storybook: 2.0.0
+      react-dom: 8.0.0
+      react-halo: 3.0.0
+      react-icons: 1.1.4
+      react-markdown: 0.1.0
+      react-testing-library: 4.0.1
+      react-virtuoso: 1.0.0
+      read: 1.0.1
+      recharts: 1.1.0
+      record: 4.0.0
+      record-extra: 5.0.1
+      record-ptional-fields: 0.1.2
+      record-studio: 1.0.4
+      refs: 6.0.0
+      remotedata: 5.0.0
+      resource: 2.0.1
+      resourcet: 1.0.0
+      result: 1.0.3
+      return: 0.2.0
+      ring-modules: 5.0.1
+      rito: 0.3.4
+      routing: 11.0.0
+      routing-duplex: 0.7.0
+      run: 5.0.0
+      safe-coerce: 2.0.0
+      safely: 4.0.1
+      school-of-music: 1.3.0
+      selection-foldable: 0.2.0
+      selective-functors: 1.0.1
+      semirings: 7.0.0
+      signal: 13.0.0
+      simple-emitter: 3.0.1
+      simple-i18n: 2.0.1
+      simple-json: 9.0.0
+      simple-ulid: 3.0.0
+      sized-matrices: 1.0.0
+      sized-vectors: 5.0.2
+      slug: 3.0.8
+      small-ffi: 4.0.1
+      soundfonts: 4.1.0
+      sparse-matrices: 1.3.0
+      sparse-polynomials: 2.0.5
+      spec: 7.5.5
+      spec-mocha: 5.1.0
+      spec-quickcheck: 5.0.0
+      splitmix: 2.1.0
+      ssrs: 1.0.0
+      st: 6.2.0
+      statistics: 0.3.2
+      strictlypositiveint: 1.0.1
+      string-parsers: 8.0.0
+      strings: 6.0.1
+      strings-extra: 4.0.0
+      stringutils: 0.0.12
+      substitute: 0.2.3
+      supply: 0.2.0
+      svg-parser: 3.0.0
+      systemd-journald: 0.3.0
+      tagged: 4.0.2
+      tailrec: 6.1.0
+      tecton: 0.2.1
+      tecton-halogen: 0.2.0
+      test-unit: 17.0.0
+      thermite: 6.3.1
+      thermite-dom: 0.3.1
+      these: 6.0.0
+      transformation-matrix: 1.0.1
+      transformers: 6.0.0
+      tree-rose: 4.0.2
+      ts-bridge: 4.0.0
+      tuples: 7.0.0
+      two-or-more: 1.0.0
+      type-equality: 4.0.1
+      typedenv: 2.0.1
+      typelevel: 6.0.0
+      typelevel-lists: 2.1.0
+      typelevel-peano: 1.0.1
+      typelevel-prelude: 7.0.0
+      typelevel-regex: 0.0.3
+      typelevel-rows: 0.1.0
+      uint: 7.0.0
+      ulid: 3.0.1
+      uncurried-transformers: 1.1.0
+      undefined: 2.0.0
+      undefined-is-not-a-problem: 1.1.0
+      unfoldable: 6.0.0
+      unicode: 6.0.0
+      unique: 0.6.1
+      unlift: 1.0.1
+      unordered-collections: 3.0.1
+      unsafe-coerce: 6.0.0
+      unsafe-reference: 5.0.0
+      untagged-to-tagged: 0.1.4
+      untagged-union: 1.0.0
+      uri: 9.0.0
+      uuid: 9.0.0
+      uuidv4: 1.0.0
+      validation: 6.0.0
+      variant: 8.0.0
+      variant-encodings: 2.0.0
+      vectorfield: 1.0.1
+      vectors: 2.1.0
+      versions: 7.0.0
+      visx: 0.0.2
+      web-clipboard: 5.0.0
+      web-cssom: 2.0.0
+      web-cssom-view: 0.1.0
+      web-dom: 6.0.0
+      web-dom-parser: 8.0.0
+      web-dom-xpath: 3.0.0
+      web-encoding: 3.0.0
+      web-events: 4.0.0
+      web-fetch: 4.0.1
+      web-file: 4.0.0
+      web-geometry: 0.1.0
+      web-html: 4.1.0
+      web-pointerevents: 2.0.0
+      web-proletarian: 1.0.0
+      web-promise: 3.2.0
+      web-resize-observer: 2.1.0
+      web-router: 1.0.0
+      web-socket: 4.0.0
+      web-storage: 5.0.0
+      web-streams: 4.0.0
+      web-touchevents: 4.0.0
+      web-uievents: 5.0.0
+      web-url: 2.0.0
+      web-workers: 1.1.0
+      web-xhr: 5.0.1
+      webextension-polyfill: 0.1.0
+      webgpu: 0.0.1
+      which: 2.0.0
+      yoga-fetch: 1.0.1
+      yoga-json: 5.1.0
+      yoga-om: 0.1.0
+      yoga-postgres: 6.0.0
+      yoga-tree: 1.0.0
+      z3: 0.0.2
+      zipperarray: 2.0.0
+  extra_packages: {}
+packages:
+  aff:
+    type: registry
+    version: 7.1.0
+    integrity: sha256-7hOC6uQO9XBAI5FD8F33ChLjFAiZVfd4BJMqlMh7TNU=
+    dependencies:
+      - arrays
+      - bifunctors
+      - control
+      - datetime
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - functions
+      - maybe
+      - newtype
+      - parallel
+      - prelude
+      - refs
+      - tailrec
+      - transformers
+      - unsafe-coerce
+  arrays:
+    type: registry
+    version: 7.3.0
+    integrity: sha256-tmcklBlc/muUtUfr9RapdCPwnlQeB3aSrC4dK85gQlc=
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - functions
+      - maybe
+      - nonempty
+      - partial
+      - prelude
+      - safe-coerce
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  bifunctors:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-/gZwC9YhNxZNQpnHa5BIYerCGM2jeX9ukZiEvYxm5Nw=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  const:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-tNrxDW8D8H4jdHE2HiPzpLy08zkzJMmGHdRqt5BQuTc=
+    dependencies:
+      - invariant
+      - newtype
+      - prelude
+  contravariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-TP+ooAp3vvmdjfQsQJSichF5B4BPDHp3wAJoWchip6c=
+    dependencies:
+      - const
+      - either
+      - newtype
+      - prelude
+      - tuples
+  control:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sH7Pg9E96JCPF9PIA6oQ8+BjTyO/BH1ZuE/bOcyj4Jk=
+    dependencies:
+      - newtype
+      - prelude
+  datetime:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-g/5X5BBegQWLpI9IWD+sY6mcaYpzzlW5lz5NBzaMtyI=
+    dependencies:
+      - bifunctors
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - functions
+      - gen
+      - integers
+      - lists
+      - maybe
+      - newtype
+      - numbers
+      - ordered-collections
+      - partial
+      - prelude
+      - tuples
+  distributive:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-HTDdmEnzigMl+02SJB88j+gAXDx9VKsbvR4MJGDPbOQ=
+    dependencies:
+      - identity
+      - newtype
+      - prelude
+      - tuples
+      - type-equality
+  effect:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-eBtZu+HZcMa5HilvI6kaDyVX3ji8p0W9MGKy2K4T6+M=
+    dependencies:
+      - prelude
+  either:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-6hgTPisnMWVwQivOu2PKYcH8uqjEOOqDyaDQVUchTpY=
+    dependencies:
+      - control
+      - invariant
+      - maybe
+      - prelude
+  enums:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-HWaD73JFLorc4A6trKIRUeDMdzE+GpkJaEOM1nTNkC8=
+    dependencies:
+      - control
+      - either
+      - gen
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tuples
+      - unfoldable
+  exceptions:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-y/xTAEIZIARCE+50/u1di0ncebJ+CIwNOLswyOWzMTw=
+    dependencies:
+      - effect
+      - either
+      - maybe
+      - prelude
+  exists:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-A0JQHpTfo1dNOj9U5/Fd3xndlRSE0g2IQWOGor2yXn8=
+    dependencies:
+      - unsafe-coerce
+  foldable-traversable:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-fLeqRYM4jUrZD5H4WqcwUgzU7XfYkzO4zhgtNc3jcWM=
+    dependencies:
+      - bifunctors
+      - const
+      - control
+      - either
+      - functors
+      - identity
+      - maybe
+      - newtype
+      - orders
+      - prelude
+      - tuples
+  foreign:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1ORiqoS3HW+qfwSZAppHPWy4/6AQysxZ2t29jcdUMNA=
+    dependencies:
+      - either
+      - functions
+      - identity
+      - integers
+      - lists
+      - maybe
+      - prelude
+      - strings
+      - transformers
+  functions:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-adMyJNEnhGde2unHHAP79gPtlNjNqzgLB8arEOn9hLI=
+    dependencies:
+      - prelude
+  functors:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-zfPWWYisbD84MqwpJSZFlvM6v86McM68ob8p9s27ywU=
+    dependencies:
+      - bifunctors
+      - const
+      - contravariant
+      - control
+      - distributive
+      - either
+      - invariant
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - tuples
+      - unsafe-coerce
+  gen:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-f7yzAXWwr+xnaqEOcvyO3ezKdoes8+WXWdXIHDBCAPI=
+    dependencies:
+      - either
+      - foldable-traversable
+      - identity
+      - maybe
+      - newtype
+      - nonempty
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  identity:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-4wY0XZbAksjY6UAg99WkuKyJlQlWAfTi2ssadH0wVMY=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  integers:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-sf+sK26R1hzwl3NhXR7WAu9zCDjQnfoXwcyGoseX158=
+    dependencies:
+      - maybe
+      - numbers
+      - prelude
+  invariant:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-RGWWyYrz0Hs1KjPDA+87Kia67ZFBhfJ5lMGOMCEFoLo=
+    dependencies:
+      - control
+      - prelude
+  js-date:
+    type: registry
+    version: 8.0.0
+    integrity: sha256-6TVF4DWg5JL+jRAsoMssYw8rgOVALMUHT1CuNZt8NRo=
+    dependencies:
+      - datetime
+      - effect
+      - exceptions
+      - foreign
+      - integers
+      - now
+  lazy:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-lMsfFOnlqfe4KzRRiW8ot5ge6HtcU3Eyh2XkXcP5IgU=
+    dependencies:
+      - control
+      - foldable-traversable
+      - invariant
+      - prelude
+  lists:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-EKF15qYqucuXP2lT/xPxhqy58f0FFT6KHdIB/yBOayI=
+    dependencies:
+      - bifunctors
+      - control
+      - foldable-traversable
+      - lazy
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  maybe:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-5cCIb0wPwbat2PRkQhUeZO0jcAmf8jCt2qE0wbC3v2Q=
+    dependencies:
+      - control
+      - invariant
+      - newtype
+      - prelude
+  media-types:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-n/4FoGBasbVSYscGVRSyBunQ6CZbL3jsYL+Lp01mc9k=
+    dependencies:
+      - newtype
+      - prelude
+  newtype:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-gdrQu8oGe9eZE6L3wOI8ql/igOg+zEGB5ITh2g+uttw=
+    dependencies:
+      - prelude
+      - safe-coerce
+  nonempty:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-54ablJZUHGvvlTJzi3oXyPCuvY6zsrWJuH/dMJ/MFLs=
+    dependencies:
+      - control
+      - foldable-traversable
+      - maybe
+      - prelude
+      - tuples
+      - unfoldable
+  now:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-xZ7x37ZMREfs6GCDw/h+FaKHV/3sPWmtqBZRGTxybQY=
+    dependencies:
+      - datetime
+      - effect
+  nullable:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-yiGBVl3AD+Guy4kNWWeN+zl1gCiJK+oeIFtZtPCw4+o=
+    dependencies:
+      - effect
+      - functions
+      - maybe
+  numbers:
+    type: registry
+    version: 9.0.1
+    integrity: sha256-/9M6aeMDBdB4cwYDeJvLFprAHZ49EbtKQLIJsneXLIk=
+    dependencies:
+      - functions
+      - maybe
+  ordered-collections:
+    type: registry
+    version: 3.1.1
+    integrity: sha256-boSYHmlz4aSbwsNN4VxiwCStc0t+y1F7BXmBS+1JNtI=
+    dependencies:
+      - arrays
+      - foldable-traversable
+      - gen
+      - lists
+      - maybe
+      - partial
+      - prelude
+      - st
+      - tailrec
+      - tuples
+      - unfoldable
+  orders:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-nBA0g3/ai0euH8q9pSbGqk53W2q6agm/dECZTHcoink=
+    dependencies:
+      - newtype
+      - prelude
+  parallel:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-gUC9i4Txnx9K9RcMLsjujbwZz6BB1bnE2MLvw4GIw5o=
+    dependencies:
+      - control
+      - effect
+      - either
+      - foldable-traversable
+      - functors
+      - maybe
+      - newtype
+      - prelude
+      - profunctor
+      - refs
+      - transformers
+  partial:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-fwXerld6Xw1VkReh8yeQsdtLVrjfGiVuC5bA1Wyo/J4=
+    dependencies: []
+  prelude:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-o8p6SLYmVPqzXZhQFd2hGAWEwBoXl1swxLG/scpJ0V0=
+    dependencies: []
+  profunctor:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-99NzxFgTr4CGlCSRYG1kShL+JhYbihhHtbOk1/0R5zI=
+    dependencies:
+      - control
+      - distributive
+      - either
+      - exists
+      - invariant
+      - newtype
+      - prelude
+      - tuples
+  refs:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Vgwne7jIbD3ZMoLNNETLT8Litw6lIYo3MfYNdtYWj9s=
+    dependencies:
+      - effect
+      - prelude
+  safe-coerce:
+    type: registry
+    version: 2.0.0
+    integrity: sha256-a1ibQkiUcbODbLE/WAq7Ttbbh9ex+x33VCQ7GngKudU=
+    dependencies:
+      - unsafe-coerce
+  st:
+    type: registry
+    version: 6.2.0
+    integrity: sha256-z9X0WsOUlPwNx9GlCC+YccCyz8MejC8Wb0C4+9fiBRY=
+    dependencies:
+      - partial
+      - prelude
+      - tailrec
+      - unsafe-coerce
+  strings:
+    type: registry
+    version: 6.0.1
+    integrity: sha256-WssD3DbX4OPzxSdjvRMX0yvc9+pS7n5gyPv5I2Trb7k=
+    dependencies:
+      - arrays
+      - control
+      - either
+      - enums
+      - foldable-traversable
+      - gen
+      - integers
+      - maybe
+      - newtype
+      - nonempty
+      - partial
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+      - unsafe-coerce
+  tailrec:
+    type: registry
+    version: 6.1.0
+    integrity: sha256-Xx19ECVDRrDWpz9D2GxQHHV89vd61dnXxQm0IcYQHGk=
+    dependencies:
+      - bifunctors
+      - effect
+      - either
+      - identity
+      - maybe
+      - partial
+      - prelude
+      - refs
+  transformers:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-Pzw40HjthX77tdPAYzjx43LK3X5Bb7ZspYAp27wksFA=
+    dependencies:
+      - control
+      - distributive
+      - effect
+      - either
+      - exceptions
+      - foldable-traversable
+      - identity
+      - lazy
+      - maybe
+      - newtype
+      - prelude
+      - tailrec
+      - tuples
+      - unfoldable
+  tuples:
+    type: registry
+    version: 7.0.0
+    integrity: sha256-1rXgTomes9105BjgXqIw0FL6Fz1lqqUTLWOumhWec1M=
+    dependencies:
+      - control
+      - invariant
+      - prelude
+  type-equality:
+    type: registry
+    version: 4.0.1
+    integrity: sha256-Hs9D6Y71zFi/b+qu5NSbuadUQXe5iv5iWx0226vOHUw=
+    dependencies: []
+  unfoldable:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-JtikvJdktRap7vr/K4ITlxUX1QexpnqBq0G/InLr6eg=
+    dependencies:
+      - foldable-traversable
+      - maybe
+      - partial
+      - prelude
+      - tuples
+  unsafe-coerce:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-IqIYW4Vkevn8sI+6aUwRGvd87tVL36BBeOr0cGAE7t0=
+    dependencies: []
+  web-dom:
+    type: registry
+    version: 6.0.0
+    integrity: sha256-1kSKWFDI4LupdmpjK01b1MMxDFW7jvatEgPgVmCmSBQ=
+    dependencies:
+      - web-events
+  web-events:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-YDt8b6u1tzGtnWyNRodne57iO8FNSGPaTCVzBUyUn4k=
+    dependencies:
+      - datetime
+      - enums
+      - foreign
+      - nullable
+  web-file:
+    type: registry
+    version: 4.0.0
+    integrity: sha256-1h5jPBkvjY71jLEdwVadXCx86/2inNoMBO//Rd3eCSU=
+    dependencies:
+      - foreign
+      - media-types
+      - web-dom
+  web-geometry:
+    type: registry
+    version: 0.1.0
+    integrity: sha256-yWJtkoPUcbS/RtU4abYvHlWol5YBMK6hGC7HGCICwwM=
+    dependencies: []
+  web-html:
+    type: registry
+    version: 4.1.0
+    integrity: sha256-ByqS/h1/yG+hjCOnOQp7L1QpIWzQENNKB1kaHtpEhlE=
+    dependencies:
+      - js-date
+      - web-dom
+      - web-file
+      - web-storage
+  web-storage:
+    type: registry
+    version: 5.0.0
+    integrity: sha256-q+6lxcnfWxus0/nDeFVtF1V+tLehZvvXQ0cduYPLksY=
+    dependencies:
+      - nullable
+      - web-events

--- a/spago.yaml
+++ b/spago.yaml
@@ -1,0 +1,18 @@
+package:
+  name: web-cssom-view
+  build:
+    strict: true
+  dependencies:
+    - aff
+    - effect
+    - maybe
+    - nullable
+    - prelude
+    - unsafe-coerce
+    - web-dom
+    - web-events
+    - web-geometry
+    - web-html
+workspace:
+  package_set:
+    registry: 47.12.0

--- a/src/Web/CSSOMView.purs
+++ b/src/Web/CSSOMView.purs
@@ -5,7 +5,7 @@ import Web.CSSOMView.MediaQueryList (MediaQueryList) as CSSOMView
 import Web.CSSOMView.MediaQueryListEvent (MediaQueryListEvent) as CSSOMView
 import Web.CSSOMView.Screen (Screen) as CSSOMView
 
-data ScrollBehavior = Auto | Smooth
+data ScrollBehavior = Auto | Instant | Smooth
 
 type ScrollToOptions =
   { left :: Number

--- a/src/Web/CSSOMView/Element.js
+++ b/src/Web/CSSOMView/Element.js
@@ -1,7 +1,3 @@
-function convertScrollToOptions(options) {
-  return options.value0 && Object.assign({}, options.value0, { behavior: options.value0.constructor.name.toLowerCase() });
-}
-
 export function getClientRects(element) {
   return function () {
     return element.getClientRects();
@@ -14,41 +10,34 @@ export function getBoundingClientRect(element) {
   };
 }
 
-export function scrollIntoView(scrollIntoViewOptions) {
+export function _scrollIntoView(scrollIntoViewOptions) {
   return function (element) {
     return function () {
-      if (scrollIntoViewOptions.value0) {
-        element.scrollIntoView({
-          block: scrollIntoViewOptions.value0.block.constructor.name.toLowerCase(),
-          inline: scrollIntoViewOptions.value0.inline.constructor.name.toLowerCase()
-        });
-      } else {
-        element.scrollIntoView();
-      }
+      element.scrollIntoView(scrollIntoViewOptions);
     };
   };
 }
 
-export function scroll(scrollToOptions) {
+export function _scroll(scrollToOptions) {
   return function (element) {
     return function () {
-      element.scrollIntoView(convertScrollToOptions(scrollToOptions));
+      element.scrollIntoView(scrollToOptions);
     };
   };
 }
 
-export function scrollTo(scrollToOptions) {
+export function _scrollTo(scrollToOptions) {
   return function (element) {
     return function () {
-      element.scrollTo(convertScrollToOptions(scrollToOptions));
+      element.scrollTo(scrollToOptions);
     };
   };
 }
 
-export function scrollBy(scrollToOptions) {
+export function _scrollBy(scrollToOptions) {
   return function (element) {
     return function () {
-      element.scrollBy(convertScrollToOptions(scrollToOptions));
+      element.scrollBy(scrollToOptions);
     };
   };
 }

--- a/src/Web/CSSOMView/Element.purs
+++ b/src/Web/CSSOMView/Element.purs
@@ -1,18 +1,34 @@
-module Web.CSSOMView.Element where
+module Web.CSSOMView.Element
+  ( clientHeight
+  , clientLeft
+  , clientTop
+  , clientWidth
+  , getBoundingClientRect
+  , getClientRects
+  , scroll
+  , scrollBy
+  , scrollHeight
+  , scrollIntoView
+  , scrollLeft
+  , scrollTo
+  , scrollTop
+  , scrollWidth
+  )
+  where
 
-import Prelude (Unit)
+import Data.Maybe (Maybe(..))
 import Effect (Effect)
-import Data.Maybe (Maybe)
+import Prelude (Unit)
+import Web.CSSOMView (ScrollBehavior(..), ScrollIntoViewOptions, ScrollLogicalPosition(..), ScrollToOptions)
 import Web.DOM.Element (Element)
 import Web.Geometry (DOMRectList, DOMRect)
-import Web.CSSOMView (ScrollIntoViewOptions, ScrollToOptions)
 
 foreign import getClientRects :: Element -> Effect DOMRectList
 foreign import getBoundingClientRect :: Element -> Effect DOMRect
-foreign import scrollIntoView :: Maybe ScrollIntoViewOptions -> Element -> Effect Unit
-foreign import scroll :: Maybe ScrollToOptions -> Element -> Effect Unit
-foreign import scrollTo :: Maybe ScrollToOptions -> Element -> Effect Unit
-foreign import scrollBy :: Maybe ScrollToOptions -> Element -> Effect Unit
+foreign import _scrollIntoView :: PrimitiveScrollIntoViewOptions -> Element -> Effect Unit
+foreign import _scroll :: PrimitiveScrollToOptions -> Element -> Effect Unit
+foreign import _scrollTo :: PrimitiveScrollToOptions -> Element -> Effect Unit
+foreign import _scrollBy :: PrimitiveScrollToOptions -> Element -> Effect Unit
 foreign import scrollTop :: Element -> Effect Number
 foreign import scrollLeft :: Element -> Effect Number
 foreign import scrollWidth :: Element -> Effect Int
@@ -21,3 +37,51 @@ foreign import clientTop :: Element -> Effect Int
 foreign import clientLeft :: Element -> Effect Int
 foreign import clientWidth :: Element -> Effect Int
 foreign import clientHeight :: Element -> Effect Int
+
+scrollIntoView :: Maybe ScrollIntoViewOptions -> Element -> Effect Unit
+scrollIntoView scrollIntoViewOptions = _scrollIntoView (primitiveScrollIntoViewOptions scrollIntoViewOptions)
+scroll :: Maybe ScrollToOptions -> Element -> Effect Unit
+scroll scrollToOptions = _scroll (primitiveScrollToOptions scrollToOptions)
+scrollTo :: Maybe ScrollToOptions -> Element -> Effect Unit
+scrollTo scrollToOptions = _scrollTo (primitiveScrollToOptions scrollToOptions)
+scrollBy :: Maybe ScrollToOptions -> Element -> Effect Unit
+scrollBy scrollToOptions = _scrollBy (primitiveScrollToOptions scrollToOptions)
+
+type PrimitiveScrollToOptions =
+  { left :: Number
+  , top :: Number
+  , behavior :: String
+  }
+
+primitiveBehavior :: ScrollBehavior -> String
+primitiveBehavior Auto = "auto"
+primitiveBehavior Instant = "instant"
+primitiveBehavior Smooth = "smooth"
+
+primitiveScrollToOptions :: Maybe ScrollToOptions -> PrimitiveScrollToOptions
+primitiveScrollToOptions Nothing = { left: 0.0, top: 0.0, behavior: "auto"  }
+primitiveScrollToOptions (Just scrollToOptions) =
+  { left: scrollToOptions.left
+  , top: scrollToOptions.top
+  , behavior: primitiveBehavior scrollToOptions.behavior
+  }
+
+type PrimitiveScrollIntoViewOptions =
+  { block :: String
+  , inline :: String
+  , behavior :: String
+  }
+
+primitiveScrollLogicalPosition :: ScrollLogicalPosition -> String
+primitiveScrollLogicalPosition Start = "start"
+primitiveScrollLogicalPosition Center = "center"
+primitiveScrollLogicalPosition End = "end"
+primitiveScrollLogicalPosition Nearest = "nearest"
+
+primitiveScrollIntoViewOptions :: Maybe ScrollIntoViewOptions -> PrimitiveScrollIntoViewOptions
+primitiveScrollIntoViewOptions Nothing = { block: "start", inline: "nearest", behavior: "auto" }
+primitiveScrollIntoViewOptions (Just scrollIntoViewOptions) =
+  { block: primitiveScrollLogicalPosition scrollIntoViewOptions.block
+  , inline: primitiveScrollLogicalPosition scrollIntoViewOptions.inline
+  , behavior: primitiveBehavior scrollIntoViewOptions.behavior
+  }

--- a/src/Web/CSSOMView/Window.js
+++ b/src/Web/CSSOMView/Window.js
@@ -65,44 +65,26 @@ export const pageXOffset = getter("pageXOffset");
 export const scrollY = getter("scrollY");
 export const pageYOffset = getter("pageYOffset");
 
-export function scroll(window) {
-  return function (options) {
+export function _scroll(scrollToOptions) {
+  return function (window) {
     return function () {
-      if (typeof options.value0 === "object") {
-        var newObject = Object.assign({}, options.value0);
-        newObject.behavior = newObject.behavior.value0.constructor.name.toLowerCase();
-        window.scroll(newObject);
-      } else {
-        window.scroll();
-      }
+      window.scrollBy(scrollToOptions);
     };
   };
 }
 
-export function scrollTo(options) {
+export function _scrollTo(scrollToOptions) {
   return function (window) {
     return function () {
-      if (typeof options.value0 === "object") {
-        var newObject = Object.assign({}, options.value0);
-        newObject.behavior = newObject.behavior.value0.constructor.name.toLowerCase();
-        window.scrollTo(newObject);
-      } else {
-        window.scrollTo();
-      }
+      window.scrollBy(scrollToOptions);
     };
   };
 }
 
-export function scrollBy(options) {
+export function _scrollBy(scrollToOptions) {
   return function (window) {
     return function () {
-      if (typeof options.value0 === "object") {
-        var newObject = Object.assign({}, options.value0);
-        newObject.behavior = newObject.behavior.value0.constructor.name.toLowerCase();
-        window.scrollBy(newObject);
-      } else {
-        window.scrollBy();
-      }
+      window.scrollBy(scrollToOptions);
     };
   };
 }

--- a/src/Web/CSSOMView/Window.purs
+++ b/src/Web/CSSOMView/Window.purs
@@ -1,12 +1,35 @@
-module Web.CSSOMView.Window where
+module Web.CSSOMView.Window
+  ( devicePixelRatio
+  , innerHeight
+  , innerWidth
+  , matchMedia
+  , moveBy
+  , moveTo
+  , outerHeight
+  , outerWidth
+  , pageXOffset
+  , pageYOffset
+  , resizeBy
+  , resizeTo
+  , screen
+  , screenTop
+  , screenX
+  , screenY
+  , scroll
+  , scrollBy
+  , scrollTo
+  , scrollX
+  , scrollY
+  )
+  where
 
-import Prelude (Unit)
-import Data.Maybe (Maybe)
+import Data.Maybe (Maybe(..))
 import Effect (Effect)
-import Web.HTML.Window (Window)
-import Web.CSSOMView (ScrollToOptions)
-import Web.CSSOMView.Screen (Screen)
+import Prelude (Unit)
+import Web.CSSOMView (ScrollBehavior(..), ScrollToOptions)
 import Web.CSSOMView.MediaQueryList (MediaQueryList)
+import Web.CSSOMView.Screen (Screen)
+import Web.HTML.Window (Window)
 
 foreign import matchMedia :: String -> Window -> Effect MediaQueryList
 foreign import screen :: Window -> Screen
@@ -23,9 +46,9 @@ foreign import pageXOffset :: Window -> Effect Number
 foreign import scrollY :: Window -> Effect Number
 foreign import pageYOffset :: Window -> Effect Number
 
-foreign import scroll :: Maybe ScrollToOptions -> Window -> Effect Unit
-foreign import scrollTo :: Maybe ScrollToOptions -> Window -> Effect Unit
-foreign import scrollBy :: Maybe ScrollToOptions -> Window -> Effect Unit
+foreign import _scroll :: PrimitiveScrollToOptions -> Window -> Effect Unit
+foreign import _scrollTo :: PrimitiveScrollToOptions -> Window -> Effect Unit
+foreign import _scrollBy :: PrimitiveScrollToOptions -> Window -> Effect Unit
 
 foreign import screenX :: Window -> Effect Int
 foreign import screenLeft :: Window -> Effect Int
@@ -34,3 +57,30 @@ foreign import screenTop :: Window -> Effect Int
 foreign import outerWidth :: Window -> Effect Int
 foreign import outerHeight :: Window -> Effect Int
 foreign import devicePixelRatio :: Window -> Effect Number
+
+
+scroll :: Maybe ScrollToOptions -> Window -> Effect Unit
+scroll scrollToOptions = _scroll (primitiveScrollToOptions scrollToOptions)
+scrollTo :: Maybe ScrollToOptions -> Window -> Effect Unit
+scrollTo scrollToOptions = _scrollTo (primitiveScrollToOptions scrollToOptions)
+scrollBy :: Maybe ScrollToOptions -> Window -> Effect Unit
+scrollBy scrollToOptions = _scrollBy (primitiveScrollToOptions scrollToOptions)
+
+type PrimitiveScrollToOptions =
+  { left :: Number
+  , top :: Number
+  , behavior :: String
+  }
+
+primitiveBehavior :: ScrollBehavior -> String
+primitiveBehavior Auto = "auto"
+primitiveBehavior Instant = "instant"
+primitiveBehavior Smooth = "smooth"
+
+primitiveScrollToOptions :: Maybe ScrollToOptions -> PrimitiveScrollToOptions
+primitiveScrollToOptions Nothing = { left: 0.0, top: 0.0, behavior: "auto"  }
+primitiveScrollToOptions (Just scrollToOptions) =
+  { left: scrollToOptions.left
+  , top: scrollToOptions.top
+  , behavior: primitiveBehavior scrollToOptions.behavior
+  }


### PR DESCRIPTION
Closes #7 

Seems like specifying scroll behavior was always broken. And it wasn't even passed to the DOM API in case of `scrollIntoView`. I also added missing `"instant"` scroll behavior option. And Spago files to make local development easier.

Not sure if that's the best way to do it. Seems like a lot of boilerplate and some healthy amount of duplication. In these cases, the data structures (`ScrollToOptions` and `ScrollIntoViewOptions`) are simple and all values have static defaults (I presume `top` and `left` default to `0.0`) so we don't need to use null values. But I don't know how this approach would work in more complicated use cases.